### PR TITLE
Added tests for event removal

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -100,6 +100,44 @@ test('unsubscribes single event with name and callback', function (t) {
   });
 });
 
+test('unsubscribes single event with name and callback when subscribed twice', function (t) {
+  var emitter = new Emitter();
+  var fn = function () {
+    t.ok(false, 'should not get called');
+  };
+
+  emitter.on('test', fn);
+  emitter.on('test', fn);
+  emitter.off('test', fn);
+  emitter.emit('test');
+
+  process.nextTick(function () {
+    t.end();
+  });
+});
+
+test('unsubscribes single event with name and callback when subscribed twice out of order', function (t) {
+  var emitter = new Emitter();
+  var calls = 0;
+  var fn = function () {
+    t.ok(false, 'should not get called');
+  };
+  var fn2 = function () {
+    calls++;
+  };
+
+  emitter.on('test', fn);
+  emitter.on('test', fn2);
+  emitter.on('test', fn);
+  emitter.off('test', fn);
+  emitter.emit('test');
+
+  process.nextTick(function () {
+    t.equal(calls, 1, 'callback was called');
+    t.end();
+  });
+});
+
 test('removes an event inside another event', function (t) {
   var emitter = new Emitter();
   


### PR DESCRIPTION
This PR includes tests for #5.

Note that `unsubscribes single event with name and callback when subscribed twice` currently fails while `unsubscribes single event with name and callback when subscribed twice out of order` currently passes (and should continue to pass after the fix).
