### PR TITLE
add TypeScript typing definition file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,7 @@
-declare module "tiny-emitter" {
-  class EventEmitter {
-    on   (event: string, callback: Function, ctx?: any): EventEmitter;
-    once (event: string, callback: Function, ctx?: any): EventEmitter;
-    emit (event: string, ...args: any[]): EventEmitter;
-    off  (event: string, callback?: Function): EventEmitter;
-  }
-  export = EventEmitter
+declare class EventEmitter {
+  on   (event: string, callback: Function, ctx?: any): EventEmitter;
+  once (event: string, callback: Function, ctx?: any): EventEmitter;
+  emit (event: string, ...args: any[]): EventEmitter;
+  off  (event: string, callback?: Function): EventEmitter;
 }
+export = EventEmitter

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+declare module "tiny-emitter" {
+  class EventEmitter {
+    new(...args:any[]): EventEmitter;
+    on   (event: string, callback: Function, ctx?: any): EventEmitter;
+    once (event: string, callback: Function, ctx?: any): EventEmitter;
+    emit (event: string, ...args: any[]): EventEmitter;
+    off  (event: string, callback?: Function): EventEmitter;
+  }
+  export = EventEmitter
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 declare module "tiny-emitter" {
   class EventEmitter {
-    new(...args:any[]): EventEmitter;
     on   (event: string, callback: Function, ctx?: any): EventEmitter;
     once (event: string, callback: Function, ctx?: any): EventEmitter;
     emit (event: string, ...args: any[]): EventEmitter;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 function E () {
-	// Keep this empty so it's easier to inherit from
+  // Keep this empty so it's easier to inherit from
   // (via https://github.com/lipsmack from https://github.com/scottcorgan/tiny-emitter/issues/3)
 }
 
 E.prototype = {
-	on: function (name, callback, ctx) {
+  on: function (name, callback, ctx) {
     var e = this.e || (this.e = {});
 
     (e[name] || (e[name] = [])).push({


### PR DESCRIPTION
Allow TypeScript users to import `tiny-emitter` easily through:

```typescript
import EventEmitter = require("tiny-emitter")
```

Cheers!