### PR TITLE
use interface in typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
-declare class EventEmitter {
+interface EventEmitter {
   on   (event: string, callback: Function, ctx?: any): EventEmitter;
   once (event: string, callback: Function, ctx?: any): EventEmitter;
   emit (event: string, ...args: any[]): EventEmitter;
   off  (event: string, callback?: Function): EventEmitter;
 }
-export = EventEmitter


### PR DESCRIPTION
Hi,

Your current typescript definition is causing the following error for me:

`error TS2304: Cannot find name 'EventEmitter'`

If I use an interface instead (a common approach), the error goes away.