### PR TITLE
Proposed method for exporting emitter instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,4 +63,5 @@ E.prototype = {
   }
 };
 
-module.exports = E;
+module.exports.default = E;
+module.exports.emitter = new E();


### PR DESCRIPTION
In reference to issue #16 this should allow for the importation of an already called emiter instance using this method without causing a breaking change:

````js
import { emitter } from 'tiny-emitter';
````

I didn't write it in the typescript file since I wasn't exactly sure how to. Also I haven't tested if this actually works but it should theoretically.