### PR TITLE
Created an instance.js file (issue #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # tiny-emitter
  
-A tiny (less than 1k) event emitter library. Works in the browser, in Node, and with [Browserify](http://browserify.org).
+A tiny (less than 1k) event emitter library. Works using CommonJS ([Node](https://nodejs.org/en/), [Browserify](http://browserify.org), [Webpack](https://webpack.js.org/), etc.) and also [Bower](https://bower.io/).
 
 [![browser support](https://ci.testling.com/scottcorgan/tiny-emitter.png)](https://ci.testling.com/scottcorgan/tiny-emitter)
  
 ## Install
 
-Node and Browserify
+### npm
 
 ```
 npm install tiny-emitter --save
 ```
  
-Browser
+### Bower
 
 ```
 bower install tiny-emitter --save
@@ -24,7 +24,7 @@ bower install tiny-emitter --save
 
 ## Usage
 
-### Node and Browserify
+### CommonJS (Node, Browserify, Webpack, etc.)
 
 ```js
 var Emitter = require('tiny-emitter');
@@ -50,7 +50,7 @@ emitter.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value');
 ```
 
 
-### Browser
+### Bower
 
 ```js
 var emitter = new TinyEmitter();

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bower install tiny-emitter --save
 
 ## Usage
 
-Node and Browserify
+### Node and Browserify
 
 ```js
 var Emitter = require('tiny-emitter');
@@ -37,7 +37,20 @@ emitter.on('some-event', function (arg1, arg2, arg3) {
 emitter.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value');
 ```
 
-Browser
+Alternatively, you can skip the initialization step by requiring `tiny-emitter/instance` instead. This pulls in an already initialized emitter.
+
+```js
+var emitter = require('tiny-emitter/instance');
+
+emitter.on('some-event', function (arg1, arg2, arg3) {
+ //
+});
+
+emitter.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value');
+```
+
+
+### Browser
 
 ```js
 var emitter = new TinyEmitter();

--- a/index.js
+++ b/index.js
@@ -63,4 +63,5 @@ E.prototype = {
   }
 };
 
-module.exports = E;
+module.exports.default = E;
+module.exports.emitter = new E();

--- a/index.js
+++ b/index.js
@@ -63,5 +63,4 @@ E.prototype = {
   }
 };
 
-module.exports.default = E;
-module.exports.emitter = new E();
+module.exports = E;

--- a/instance.js
+++ b/instance.js
@@ -1,0 +1,2 @@
+var E = require('./index.js');
+module.exports = new E();


### PR DESCRIPTION
For the sake of guaranteed backwards compatibility, I'm creating a new instance.js file that can be imported by doing this:

````js
import emitter from 'tiny-emitter/instance';
````

This makes it easier for browserify users to use as it allows them to avoid having to create their own extra tiny file in their local file system just for initializing the emitter.

This solves issue #16