### PR TITLE
Making sure we can import as ECMAScript 2015 module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
-declare class EventEmitter {
+export declare class EventEmitter {
   on   (event: string, callback: Function, ctx?: any): EventEmitter;
   once (event: string, callback: Function, ctx?: any): EventEmitter;
   emit (event: string, ...args: any[]): EventEmitter;
   off  (event: string, callback?: Function): EventEmitter;
 }
-export = EventEmitter


### PR DESCRIPTION
Hello,
I was trying to use ```tiny-emitter``` in a TypeScript 2.1 project and I have run into this issue. I was able to import ```tiny-emitter``` using this method:
```import EventEmitter = require('tiny-emitter');```
However I wanted to import the module as a ECMAScript 2015 module, something like:
```import { EventEmitter } from 'tiny-emitter';```

Adding the ```export``` to the ```declare class``` seems to do the trick. I hope this could be merged so others could benefit from it.