### PR TITLE
Fix typescript import error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,4 +5,4 @@ declare class EventEmitter {
   off  (event: string, callback?: Function): EventEmitter;
 }
 
-export default EventEmitter;
+export = EventEmitter;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
-export declare class EventEmitter {
+declare class EventEmitter {
   on   (event: string, callback: Function, ctx?: any): EventEmitter;
   once (event: string, callback: Function, ctx?: any): EventEmitter;
   emit (event: string, ...args: any[]): EventEmitter;
   off  (event: string, callback?: Function): EventEmitter;
 }
+
+export default EventEmitter;


### PR DESCRIPTION
Hi, I was trying to use tiny-emitter in a TypeScript 2.4.2 and [Rollup](https://rollupjs.org/) project, and I have to import tiny-emitter like this:

```js
import { EventEmitter } from 'tiny-emitter'
```

But if I do this, when I build my project use Rollup, it give me an error: `EventEmitter not exported by tiny-emitter`.

So I change the `index.d.ts` to fit TypeScript and Rollup, and now people can import tiny-emitter like this:

```js
import EventEmitter from 'tiny-emitter'
```

Since tiny-emitter only have one default export so I think this is more suitable.

Related discussion: #21