### PR TITLE
checking e is array instead of just defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ E.prototype = {
   on: function (name, callback, ctx) {
     var e = this.e || (this.e = {});
 
-    (e[name] || (e[name] = [])).push({
+    (Array.isArray(e[name]) || (e[name] = [])).push({
       fn: callback,
       ctx: ctx
     });


### PR DESCRIPTION
This fix if we are trying to intentional overwrite object's native properties as event name, like 'toString'