### PR TITLE
adding remove all function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@ npm install tiny-emitter --save
 ## Usage
 
 ```js
-var Emitter = require('tiny-emitter');
+var Emitter = require("tiny-emitter");
 var emitter = new Emitter();
 
-emitter.on('some-event', function (arg1, arg2, arg3) {
- //
+emitter.on("some-event", function(arg1, arg2, arg3) {
+  //
 });
 
-emitter.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value');
+emitter.emit("some-event", "arg1 value", "arg2 value", "arg3 value");
 ```
 
 Alternatively, you can skip the initialization step by requiring `tiny-emitter/instance` instead. This pulls in an already initialized emitter.
 
 ```js
-var emitter = require('tiny-emitter/instance');
+var emitter = require("tiny-emitter/instance");
 
-emitter.on('some-event', function (arg1, arg2, arg3) {
- //
+emitter.on("some-event", function(arg1, arg2, arg3) {
+  //
 });
 
-emitter.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value');
+emitter.emit("some-event", "arg1 value", "arg2 value", "arg3 value");
 ```
 
 ## Instance Methods
@@ -41,31 +41,35 @@ emitter.emit('some-event', 'arg1 value', 'arg2 value', 'arg3 value');
 
 Subscribe to an event
 
-* `event` - the name of the event to subscribe to
-* `callback` - the function to call when event is emitted
-* `context` - (OPTIONAL) - the context to bind the event callback to
+- `event` - the name of the event to subscribe to
+- `callback` - the function to call when event is emitted
+- `context` - (OPTIONAL) - the context to bind the event callback to
 
 ### once(event, callback[, context])
 
 Subscribe to an event only **once**
 
-* `event` - the name of the event to subscribe to
-* `callback` - the function to call when event is emitted
-* `context` - (OPTIONAL) - the context to bind the event callback to
+- `event` - the name of the event to subscribe to
+- `callback` - the function to call when event is emitted
+- `context` - (OPTIONAL) - the context to bind the event callback to
 
 ### off(event[, callback])
 
 Unsubscribe from an event or all events. If no callback is provided, it unsubscribes you from all events.
 
-* `event` - the name of the event to unsubscribe from
-* `callback` - the function used when binding to the event
+- `event` - the name of the event to unsubscribe from
+- `callback` - the function used when binding to the event
+
+### removeAll()
+
+Unsubscribe from all events
 
 ### emit(event[, arguments...])
 
 Trigger a named event
 
-* `event` - the event name to emit
-* `arguments...` - any number of arguments to pass to the event subscribers
+- `event` - the event name to emit
+- `arguments...` - any number of arguments to pass to the event subscribers
 
 ## Test and Build
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,5 @@ export declare class TinyEmitter {
   once(event: string, callback: Function, ctx?: any): this;
   emit(event: string, ...args: any[]): this;
   off(event: string, callback?: Function): this;
+  removeAll():this;
 }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-function E () {
+function E() {
   // Keep this empty so it's easier to inherit from
   // (via https://github.com/lipsmack from https://github.com/scottcorgan/tiny-emitter/issues/3)
 }
 
 E.prototype = {
-  on: function (name, callback, ctx) {
+  on: function(name, callback, ctx) {
     var e = this.e || (this.e = {});
 
     (e[name] || (e[name] = [])).push({
@@ -15,18 +15,18 @@ E.prototype = {
     return this;
   },
 
-  once: function (name, callback, ctx) {
+  once: function(name, callback, ctx) {
     var self = this;
-    function listener () {
+    function listener() {
       self.off(name, listener);
       callback.apply(ctx, arguments);
-    };
+    }
 
-    listener._ = callback
+    listener._ = callback;
     return this.on(name, listener, ctx);
   },
 
-  emit: function (name) {
+  emit: function(name) {
     var data = [].slice.call(arguments, 1);
     var evtArr = ((this.e || (this.e = {}))[name] || []).slice();
     var i = 0;
@@ -39,7 +39,7 @@ E.prototype = {
     return this;
   },
 
-  off: function (name, callback) {
+  off: function(name, callback) {
     var e = this.e || (this.e = {});
     var evts = e[name];
     var liveEvents = [];
@@ -55,10 +55,15 @@ E.prototype = {
     // Suggested by https://github.com/lazd
     // Ref: https://github.com/scottcorgan/tiny-emitter/commit/c6ebfaa9bc973b33d110a84a307742b7cf94c953#commitcomment-5024910
 
-    (liveEvents.length)
-      ? e[name] = liveEvents
-      : delete e[name];
+    liveEvents.length ? (e[name] = liveEvents) : delete e[name];
 
+    return this;
+  },
+  removeAll: function() {
+    var events = this.e || (this.e = {});
+    for (var event in events) {
+      delete events[event];
+    }
     return this;
   }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,217 +1,234 @@
-var Emitter = require('../index');
-var emitter = require('../instance');
-var test = require('tape');
+var Emitter = require("../index");
+var emitter = require("../instance");
+var test = require("tape");
 
-test('subscribes to an event', function (t) {
+test("subscribes to an event", function(t) {
   var emitter = new Emitter();
-  emitter.on('test', function () {});
+  emitter.on("test", function() {});
 
-  t.equal(emitter.e.test.length, 1, 'subscribed to event');
+  t.equal(emitter.e.test.length, 1, "subscribed to event");
   t.end();
 });
 
-test('subscribes to an event with context', function (t) {
+test("subscribes to an event with context", function(t) {
   var emitter = new Emitter();
   var context = {
     contextValue: true
   };
 
-  emitter.on('test', function () {
-    t.ok(this.contextValue, 'is in context');
-    t.end();
-  }, context);
+  emitter.on(
+    "test",
+    function() {
+      t.ok(this.contextValue, "is in context");
+      t.end();
+    },
+    context
+  );
 
-  emitter.emit('test');
+  emitter.emit("test");
 });
 
-test('subscibes only once to an event', function (t) {
+test("subscibes only once to an event", function(t) {
   var emitter = new Emitter();
 
-  emitter.once('test', function () {
-    t.notOk(emitter.e.test, 'removed event from list');
+  emitter.once("test", function() {
+    t.notOk(emitter.e.test, "removed event from list");
     t.end();
   });
 
-  emitter.emit('test');
+  emitter.emit("test");
 });
 
-test('keeps context when subscribed only once', function (t) {
+test("keeps context when subscribed only once", function(t) {
   var emitter = new Emitter();
   var context = {
     contextValue: true
   };
 
-  emitter.once('test', function () {
-    t.ok(this.contextValue, 'is in context');
-    t.notOk(emitter.e.test, 'not subscribed anymore');
-    t.end();
-  }, context);
+  emitter.once(
+    "test",
+    function() {
+      t.ok(this.contextValue, "is in context");
+      t.notOk(emitter.e.test, "not subscribed anymore");
+      t.end();
+    },
+    context
+  );
 
-  emitter.emit('test');
+  emitter.emit("test");
 });
 
-test('emits an event', function (t) {
+test("emits an event", function(t) {
   var emitter = new Emitter();
 
-  emitter.on('test', function () {
-    t.ok(true, 'triggered event');
-    t.end();
-  });
-
-  emitter.emit('test');
-});
-
-test('passes all arguments to event listener', function (t) {
-  var emitter = new Emitter();
-
-  emitter.on('test', function (arg1, arg2) {
-    t.equal(arg1, 'arg1', 'passed the first argument');
-    t.equal(arg2, 'arg2', 'passed the second argument');
+  emitter.on("test", function() {
+    t.ok(true, "triggered event");
     t.end();
   });
 
-  emitter.emit('test', 'arg1', 'arg2');
+  emitter.emit("test");
 });
 
-test('unsubscribes from all events with name', function (t) {
+test("passes all arguments to event listener", function(t) {
   var emitter = new Emitter();
-  emitter.on('test', function () {
-    t.fail('should not get called');
-  });
-  emitter.off('test');
-  emitter.emit('test')
 
-  process.nextTick(function () {
+  emitter.on("test", function(arg1, arg2) {
+    t.equal(arg1, "arg1", "passed the first argument");
+    t.equal(arg2, "arg2", "passed the second argument");
+    t.end();
+  });
+
+  emitter.emit("test", "arg1", "arg2");
+});
+
+test("unsubscribes from all events with name", function(t) {
+  var emitter = new Emitter();
+  emitter.on("test", function() {
+    t.fail("should not get called");
+  });
+  emitter.off("test");
+  emitter.emit("test");
+
+  process.nextTick(function() {
     t.end();
   });
 });
 
-test('unsubscribes single event with name and callback', function (t) {
+test("unsubscribes single event with name and callback", function(t) {
   var emitter = new Emitter();
-  var fn = function () {
-    t.fail('should not get called');
-  }
+  var fn = function() {
+    t.fail("should not get called");
+  };
 
-  emitter.on('test', fn);
-  emitter.off('test', fn);
-  emitter.emit('test')
+  emitter.on("test", fn);
+  emitter.off("test", fn);
+  emitter.emit("test");
 
-  process.nextTick(function () {
+  process.nextTick(function() {
     t.end();
   });
 });
 
 // Test added by https://github.com/lazd
 // From PR: https://github.com/scottcorgan/tiny-emitter/pull/6
-test('unsubscribes single event with name and callback when subscribed twice', function (t) {
+test("unsubscribes single event with name and callback when subscribed twice", function(t) {
   var emitter = new Emitter();
-  var fn = function () {
-    t.fail('should not get called');
+  var fn = function() {
+    t.fail("should not get called");
   };
 
-  emitter.on('test', fn);
-  emitter.on('test', fn);
+  emitter.on("test", fn);
+  emitter.on("test", fn);
 
-  emitter.off('test', fn);
-  emitter.emit('test');
+  emitter.off("test", fn);
+  emitter.emit("test");
 
-  process.nextTick(function () {
-    t.notOk(emitter.e['test'], 'removes all events');
+  process.nextTick(function() {
+    t.notOk(emitter.e["test"], "removes all events");
     t.end();
   });
 });
 
-test('unsubscribes single event with name and callback when subscribed twice out of order', function (t) {
+test("unsubscribes single event with name and callback when subscribed twice out of order", function(t) {
   var emitter = new Emitter();
   var calls = 0;
-  var fn = function () {
-    t.fail('should not get called');
+  var fn = function() {
+    t.fail("should not get called");
   };
-  var fn2 = function () {
+  var fn2 = function() {
     calls++;
   };
 
-  emitter.on('test', fn);
-  emitter.on('test', fn2);
-  emitter.on('test', fn);
-  emitter.off('test', fn);
-  emitter.emit('test');
+  emitter.on("test", fn);
+  emitter.on("test", fn2);
+  emitter.on("test", fn);
+  emitter.off("test", fn);
+  emitter.emit("test");
 
-  process.nextTick(function () {
-    t.equal(calls, 1, 'callback was called');
+  process.nextTick(function() {
+    t.equal(calls, 1, "callback was called");
     t.end();
   });
 });
 
-test('removes an event inside another event', function (t) {
+test("removes an event inside another event", function(t) {
   var emitter = new Emitter();
 
-  emitter.on('test', function () {
-    t.equal(emitter.e.test.length, 1, 'event is still in list');
+  emitter.on("test", function() {
+    t.equal(emitter.e.test.length, 1, "event is still in list");
 
-    emitter.off('test');
+    emitter.off("test");
 
-    t.notOk(emitter.e.test, 0, 'event is gone from list');
+    t.notOk(emitter.e.test, 0, "event is gone from list");
     t.end();
   });
 
-  emitter.emit('test');
+  emitter.emit("test");
 });
 
-test('event is emitted even if unsubscribed in the event callback', function (t) {
+test("event is emitted even if unsubscribed in the event callback", function(t) {
   var emitter = new Emitter();
   var calls = 0;
-  var fn = function () {
+  var fn = function() {
     calls += 1;
-    emitter.off('test', fn);
+    emitter.off("test", fn);
   };
 
-  emitter.on('test', fn);
+  emitter.on("test", fn);
 
-  emitter.on('test', function () {
+  emitter.on("test", function() {
     calls += 1;
   });
 
-  emitter.on('test', function () {
+  emitter.on("test", function() {
     calls += 1;
   });
 
-  process.nextTick(function () {
-    t.equal(calls, 3, 'all callbacks were called');
+  process.nextTick(function() {
+    t.equal(calls, 3, "all callbacks were called");
     t.end();
   });
 
-  emitter.emit('test');
+  emitter.emit("test");
 });
 
-test('calling off before any events added does nothing', function (t) {
+test("calling off before any events added does nothing", function(t) {
   var emitter = new Emitter();
-  emitter.off('test', function () {});
+  emitter.off("test", function() {});
   t.end();
 });
 
-test('emitting event that has not been subscribed to yet', function (t) {
+test("emitting event that has not been subscribed to yet", function(t) {
   var emitter = new Emitter();
 
-  emitter.emit('some-event', 'some message');
+  emitter.emit("some-event", "some message");
   t.end();
 });
 
-test('unsubscribes single event with name and callback which was subscribed once', function (t) {
+test("unsubscribes single event with name and callback which was subscribed once", function(t) {
   var emitter = new Emitter();
-  var fn = function () {
-    t.fail('event not unsubscribed');
-  }
+  var fn = function() {
+    t.fail("event not unsubscribed");
+  };
 
-  emitter.once('test', fn);
-  emitter.off('test', fn);
-  emitter.emit('test');
+  emitter.once("test", fn);
+  emitter.off("test", fn);
+  emitter.emit("test");
 
   t.end();
 });
 
-test('exports an instance', function (t) {
-  t.ok(emitter, 'exports an instance')
-  t.ok(emitter instanceof Emitter, 'an instance of the Emitter class');
+test("exports an instance", function(t) {
+  t.ok(emitter, "exports an instance");
+  t.ok(emitter instanceof Emitter, "an instance of the Emitter class");
+  t.end();
+});
+
+test("remove all events with removeAll ", function(t) {
+  var emitter = new Emitter();
+  emitter.on("test", function() {});
+  emitter.on("test2", function() {});
+  emitter.removeAll();
+  t.equal(Object.keys(emitter.e).length, 0, "remove all events");
   t.end();
 });


### PR DESCRIPTION
According to Node documentation and [removeAllListener](https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname) it's is not best practise to remove all events that added elsewhere, but sometimes it's good to have this functionality.