### PR TITLE
Add TypeScript types to make TinyEmitter newable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,3 +4,12 @@ export declare class TinyEmitter {
   emit(event: string, ...args: any[]): this;
   off(event: string, callback?: Function): this;
 }
+
+interface TinyEmitterStatic {
+  (): TinyEmitter;
+  new(): TinyEmitter;
+}
+
+declare const Emitter: TinyEmitterStatic;
+
+export = Emitter;


### PR DESCRIPTION
Fixes the following error when calling `TinyEmitter()` or `new TinyEmitter()` in TypeScript:

> Cannot use 'new' with an expression whose type lacks a call or construct signature.