### PR TITLE
Fix TypeScript export error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,4 +12,4 @@ interface TinyEmitterStatic {
 
 declare const Emitter: TinyEmitterStatic;
 
-export = Emitter;
+export default Emitter;


### PR DESCRIPTION
This is a follow-up to #36, which introduced a TypeScript error in index.d.ts:

> An export assignment cannot be used in a module with other exported
> elements.

This was caused by a last-minute change from:

```typescript
export default Emitter;
```

to:

```typescript
export = Emitter;
```

This PR restores the ES6 export style (which still works with CommonJS `require`).